### PR TITLE
Add long click and dragging support

### DIFF
--- a/src/mouse.cpp
+++ b/src/mouse.cpp
@@ -1,0 +1,48 @@
+#include "mouse.hpp"
+
+#include "debug.hpp"
+#include "timer.hpp"
+
+MouseManager::MouseManager(ui::Widget * target)
+{
+    target->mouse.down += [=](auto &ev) {
+        reset();
+        if (ev.left) {
+            prev = ev;
+            start = timer::now();
+        }
+    };
+
+    target->mouse.up += [=](auto &ev) {
+        if (!is_active()) return;
+        if (is_drag) {
+            drag_end(ev);
+        } else if (timer::now() - start >= long_click_delay_s) {
+            long_click(ev);
+        } else {
+            short_click(ev);
+        }
+        reset();
+    };
+
+    target->mouse.move += [=](auto &ev) {
+        if (!is_active()) return;
+        int tolerance = is_drag ? dragging_tolerance : drag_start_tolerance;
+        if (std::abs(ev.x - prev.x) > tolerance || std::abs(ev.y - prev.y) > tolerance) {
+            if (is_drag) {
+                dragging(ev);
+            } else {
+                is_drag = true;
+                drag_start(prev);
+            }
+            prev = ev;
+        }
+    };
+
+    target->mouse.leave += [=](auto &ev) {
+        // only submit drag_end, not one of the click events
+        if (is_active() && is_drag)
+            drag_end(ev);
+        reset();
+    };
+}

--- a/src/mouse.hpp
+++ b/src/mouse.hpp
@@ -1,0 +1,47 @@
+#ifndef RMP_MOUSE_HPP
+#define RMP_MOUSE_HPP
+
+#include <rmkit.h>
+
+class MouseManager {
+protected:
+    input::SynMotionEvent prev;
+    double start = -1;
+    bool is_drag = false;
+
+    // Convert this into a drag event once the x or y delta is > tolerance.
+    int drag_start_tolerance = 50;
+    // Once dragging, only submit events when the x or y delta > tolerance.
+    // This limits the number of dragging events.
+    int dragging_tolerance = 25;
+
+    double long_click_delay_s = 0.5;
+
+    void reset() { start = -1; is_drag = false; }
+    bool is_active() { return start > 0; }
+
+public:
+    // Events
+    ui::MOUSE_EVENT drag_start;
+    ui::MOUSE_EVENT dragging;
+    ui::MOUSE_EVENT drag_end;
+    ui::MOUSE_EVENT short_click;
+    ui::MOUSE_EVENT long_click;
+
+    // MouseManager registers itself as a mouse event handler in target. The
+    // caller is responsible for ensuring that MouseManager outlives target.
+    MouseManager(ui::Widget * target);
+
+    void set_drag_tolerance(int drag_start, int dragging)
+    {
+        drag_start_tolerance = drag_start;
+        dragging_tolerance = drag_start;
+    }
+
+    void set_long_click_delay(double secs)
+    {
+        long_click_delay_s = secs;
+    }
+};
+
+#endif // RMP_MOUSE_HPP

--- a/src/ui/game_scene.cpp
+++ b/src/ui/game_scene.cpp
@@ -105,14 +105,23 @@ GameScene::GameScene() : frontend()
         set_params(midend_get_presets(me, NULL)->entries[idx].params);
     };
 
-    // Canvas
-    canvas->mouse.down += [=](auto &ev) {
+    // Canvas mouse events
+    canvas_mouse = std::make_shared<MouseManager>(canvas);
+    canvas_mouse->short_click += [=](auto &ev) {
         handle_canvas_event(ev, LEFT_BUTTON);
-    };
-    canvas->mouse.up += [=](auto &ev) {
         handle_canvas_event(ev, LEFT_RELEASE);
     };
-    canvas->mouse.leave += [=](auto &ev) {
+    canvas_mouse->long_click += [=](auto &ev) {
+        handle_canvas_event(ev, RIGHT_BUTTON);
+        handle_canvas_event(ev, RIGHT_RELEASE);
+    };
+    canvas_mouse->drag_start += [=](auto &ev) {
+        handle_canvas_event(ev, LEFT_BUTTON);
+    };
+    canvas_mouse->dragging += [=](auto &ev) {
+        handle_canvas_event(ev, LEFT_DRAG);
+    };
+    canvas_mouse->drag_end += [=](auto &ev) {
         handle_canvas_event(ev, LEFT_RELEASE);
     };
 }

--- a/src/ui/game_scene.hpp
+++ b/src/ui/game_scene.hpp
@@ -5,6 +5,7 @@
 
 #include <rmkit.h>
 
+#include "mouse.hpp"
 #include "puzzles.hpp"
 #include "timer.hpp"
 #include "ui/canvas.hpp"
@@ -60,6 +61,8 @@ protected:
     void handle_puzzle_key(int key_id);
     void handle_puzzle_key(int x, int y, int key_id);
     void handle_canvas_event(input::SynMotionEvent & evt, int key_id);
+
+    std::shared_ptr<MouseManager> canvas_mouse;
 };
 
 


### PR DESCRIPTION
@raisjn, this is what got me to look at touch events again (from rmkit-dev/rmkit#74). I had a TODO in the mouse.down event to ignore multitouch.

I'm curious if you think gestures would be a better way to get at what I'm doing here, or if this extra layer on top of mouse events is its own thing. I'm not sure if this is something that would belong in rmkit -- it would be a fair amount of extra processing on top of every mouse event, so probably not something to support by default. But maybe there's something useful here. I'm not thrilled with the way GameScene has to keep the pointer to MouseManager -- it seems like it would be better to have the Widget be responsible, but that would mean reaching to rmkit internals 🤷

I'm looking to support a couple things:

1. "dragging" events. once dragging is detected (a down followed by moving beyond a certain threshold), you get a drag_start event, then dragging events, then drag_end.
2. long click vs short click. Long click is down + a configurable amount of delay + up. Short click is the same but without the delay. Both of these use the same threshold as dragging, and are only triggered when you _haven't_ moved beyond that threshold.