### PR TITLE
Change include order.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,8 +3,8 @@
 
 #include <rmkit.h>
 
-#include "game_list.hpp"
 #include "puzzles.hpp"
+#include "game_list.hpp"
 #include "ui/chooser_scene.hpp"
 #include "ui/game_scene.hpp"
 


### PR DESCRIPTION
Because game_list.hpp doesn't declare the game type at all, it must come after puzzles.hpp.