### PR TITLE
[kobo] upgrade rmkit and support ARCH=kobo

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,9 +53,9 @@ jobs:
         shell: bash
         run: |
           if [[ "${GITHUB_REF##*/}" == v* ]]; then
-            make puzzles ARCH=arm BUILD=release RMP_VERSION=${GITHUB_REF##*/}
+            make puzzles ARCH=rm BUILD=release RMP_VERSION=${GITHUB_REF##*/}
           else
-            make puzzles ARCH=arm BUILD=release
+            make puzzles ARCH=rm BUILD=release
           fi
 
       - name: Gzip artifact

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
 FROM ghcr.io/toltec-dev/python:v1.4
 
+
+RUN echo "Upgrading OKP to 0.53+"
 # for rmkit
 RUN pip3 install okp

--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,9 @@ INCLUDES  = -I./ -Isrc/ -Ivendor/inih -Ivendor/puzzles
 INCLUDES += -isystem $(BUILD_DIR)/
 
 CXXFLAGS  = -Wall $(INCLUDES) $(RMKIT_FLAGS) $(BUILD_FLAGS)
+ifeq ($(ARCH), kobo)
 CXXFLAGS += -static -static-libstdc++ -static-libgcc
+endif
 CXXFLAGS += -fdata-sections -ffunction-sections -Wl,--gc-sections
 CXXFLAGS += -D'RMP_COMPILE_DATE="$(RMP_COMPILE_DATE)"'
 ifneq ($(strip $(RMP_VERSION)),)

--- a/Makefile
+++ b/Makefile
@@ -29,13 +29,18 @@ resim: default
 
 
 #### rmkit
-RMKIT_FLAGS = -D"REMARKABLE=1" \
+RMKIT_FLAGS = -D"RMKIT_IMPLEMENTATION" -D'FONT_EMBED_H="${BUILD_DIR}/font_embed.h"'\
 	-pthread -lpthread
+
+ifeq ($(ARCH),kobo)
+	RMKIT_FLAGS+= -D"KOBO=1"
+endif
 
 $(BUILD_DIR)/rmkit.h:
 	cd vendor/rmkit && $(MAKE) rmkit.h
 	mkdir -p $(dir $@)
 	mv vendor/rmkit/src/build/rmkit.h $(BUILD_DIR)
+	cp vendor/rmkit/src/rmkit/font_embed.h $(BUILD_DIR)
 	cp vendor/rmkit/src/build/$(STB) $(BUILD_DIR)
 
 
@@ -55,6 +60,7 @@ INCLUDES  = -I./ -Isrc/ -Ivendor/inih -Ivendor/puzzles
 INCLUDES += -isystem $(BUILD_DIR)/
 
 CXXFLAGS  = -Wall $(INCLUDES) $(RMKIT_FLAGS) $(BUILD_FLAGS)
+CXXFLAGS += -static -static-libstdc++ -static-libgcc
 CXXFLAGS += -fdata-sections -ffunction-sections -Wl,--gc-sections
 CXXFLAGS += -D'RMP_COMPILE_DATE="$(RMP_COMPILE_DATE)"'
 ifneq ($(strip $(RMP_VERSION)),)

--- a/defs.mk
+++ b/defs.mk
@@ -7,7 +7,7 @@ MAKEFLAGS += --no-builtin-rules
 .SUFFIXES:
 
 
-export ARCH ?= arm
+export ARCH ?= rm
 export BUILD ?= debug
 export BUILD_ROOT ?= build
 export BUILD_DIR ?= $(BUILD_ROOT)/$(BUILD)
@@ -19,7 +19,11 @@ export RMP_VERSION ?= $(shell git tag --sort v:refname \
 
 DOCKER_ENV=-e ARCH -e BUILD -e BUILD_ROOT -e BUILD_DIR -e RMP_COMPILE_DATE -e RMP_VERSION
 
-ifeq ($(ARCH),arm)
+ifeq ($(ARCH),rm)
+	CXX = arm-linux-gnueabihf-g++
+	CC  = arm-linux-gnueabihf-gcc
+	STB = stb.arm.o
+else ifeq ($(ARCH),kobo)
 	CXX = arm-linux-gnueabihf-g++
 	CC  = arm-linux-gnueabihf-gcc
 	STB = stb.arm.o


### PR DESCRIPTION
This patch adds kobo support. 

To do so:

* adds and uses `ARCH=kobo`
* updates compile to use -DRMKIT_IMPLEMENTATION
* renames default ARCH to `rm`
* adds font_embed.h for embedding font into the binary. this is only used for ARCH=kobo in rmkit because kobo doesn't have fonts on device. can supply your own font_embed.h file for custom fonts
* modifies Dockerfile because okp>=0.53 is required
* makes compilation static (this should only be necessary on kobo)

TODO: the compilation should likely add a "strip" step to reduce the size of puzzles because of the static compilation