### PR TITLE
[rmkit] update to latest rmkit (09/09/23)

### DIFF
--- a/src/ui/canvas.cpp
+++ b/src/ui/canvas.cpp
@@ -104,7 +104,7 @@ void shrink_update_rect(framebuffer::FBRect &rect, framebuffer::FB * fb)
 
 void Canvas::render()
 {
-    if (full_refresh && !ui::MainLoop::overlay_is_visible) {
+    if (full_refresh && !ui::MainLoop::overlay_is_visible()) {
         full_refresh = false;
         // Clear ghosting by running a FULL update at the next tick.
         ui::set_timeout([=]() {

--- a/src/ui/game_menu.cpp
+++ b/src/ui/game_menu.cpp
@@ -54,10 +54,6 @@ public:
                           label.c_str(), style.font_size, WHITE);
     }
 
-    void on_mouse_click(input::SynMotionEvent &ev)
-    {
-        ui::MainLoop::hide_overlay();
-    }
 };
 
 GameMenu::GameMenu(midend * me, const game *g, int x, int y, int w, int h)
@@ -84,8 +80,8 @@ GameMenu::GameMenu(midend * me, const game *g, int x, int y, int w, int h)
             // overlay is hidden. So hide the overlay at the next tick (instead
             // of immediately), after all other events have been handled.
             ui::set_timeout([=]() {
-                if (ui::MainLoop::overlay == scene)
-                    ui::MainLoop::hide_overlay();
+                if (ui::MainLoop::overlay_is_visible(scene))
+                    ui::MainLoop::hide_overlay(scene);
                 else
                     on_hide();
             }, 0);
@@ -94,7 +90,11 @@ GameMenu::GameMenu(midend * me, const game *g, int x, int y, int w, int h)
     };
 
     // Menu
-    layout.pack_start(new HeaderButton(0, 0, w, 100, "Menu"));
+    auto header_btn = new HeaderButton(0, 0, w, 100, "Menu");
+    layout.pack_start(header_btn);
+    header_btn->mouse.click += [=](auto ev) {
+      ui::MainLoop::hide_overlay(scene);
+    };
 
     // Game buttons
     layout.pack_start(new_game_btn = add_button("  New game", 90));

--- a/src/ui/game_over.hpp
+++ b/src/ui/game_over.hpp
@@ -20,13 +20,13 @@ public:
         new_game_btn = new ui::Button(0, 0, w/2, 100, "New game");
         new_game_btn->set_style(ui::Stylesheet().border_all());
         new_game_btn->mouse.click += [=](auto &ev) {
-            ui::MainLoop::hide_overlay();
+            ui::MainLoop::hide_overlay(this->scene);
         };
 
         menu_btn = new ui::Button(0, 0, w/2, 100, "Change type");
         menu_btn->set_style(ui::Stylesheet().border_all());
         menu_btn->mouse.click += [=](auto &ev) {
-            ui::MainLoop::hide_overlay();
+            ui::MainLoop::hide_overlay(this->scene);
         };
     }
 

--- a/src/ui/game_scene.cpp
+++ b/src/ui/game_scene.cpp
@@ -192,8 +192,7 @@ GameMenu* GameScene::build_menu(int x, int y, int w, int h)
         if (wants_full_refresh())
             canvas->full_refresh = true;
         // Only destroy the overlay if it's the game menu's scene
-        if (ui::MainLoop::overlay == game_menu->scene)
-            ui::MainLoop::overlay = nullptr;
+        ui::MainLoop::hide_overlay(game_menu->scene);
         game_menu = nullptr;
     };
 
@@ -233,8 +232,7 @@ HelpDialog* GameScene::build_help()
         if (wants_full_refresh())
             canvas->full_refresh = true;
         // Only destroy the overlay if it's the dialog's scene
-        if (ui::MainLoop::overlay == help_dlg->scene)
-            ui::MainLoop::overlay = NULL;
+        ui::MainLoop::hide_overlay(help_dlg->scene);
         // There's a circular ref between dialog and scene, so
         // we can't delete the dialog or we'll segfault when
         // the scene _also_ tries to delete the dialog


### PR DESCRIPTION
update remarkable_puzzles to be compatible with latest rmkit.

reasons to update rmkit: 

* supports scene stacks
* supports kobo elipsa 2e

to support new rmkit:

* hide_overlay now requires a scene
* overlay_is_visible is a function